### PR TITLE
Fix [DEPRECATION WARNING]

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 # tasks file for vmwaretools
 
-- include: RedHat.yml
+- import_tasks: RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: Ubuntu.yml
+- import_tasks: Ubuntu.yml
   when: ansible_distribution == 'Ubuntu'
 
-- include: Debian.yml
+- import_tasks: Debian.yml
   when: ansible_distribution == 'Debian'
 
-- include: Suse.yml
+- import_tasks: Suse.yml
   when: ansible_os_family == 'Suse'
 
-- include: FreeBSD.yml
+- import_tasks: FreeBSD.yml
   when: ansible_os_family == 'FreeBSD'


### PR DESCRIPTION
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions. This feature will be removed in a future release. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg