### PR TITLE
Fix [DEPRECATION WARNING]

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -37,8 +37,7 @@
 
     - name: Install vmware-tools
       yum:
-        name: "{{ item }}"
-      loop:
+        name:
         - vmware-tools-esx-nox
         - vmware-tools-esx-kmods
       register: result

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -38,7 +38,7 @@
     - name: Install vmware-tools
       yum:
         name: "{{ item }}"
-      with_items:
+      loop:
         - vmware-tools-esx-nox
         - vmware-tools-esx-kmods
       register: result


### PR DESCRIPTION
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use 
`name: ['vmware-tools-esx-nox', 'vmware-tools-esx-kmods']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.